### PR TITLE
UI baseline

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Synergy CRM</title>
-    <link rel="stylesheet" href="/hubspot-theme.css?v7" />
+    <link rel="stylesheet" href="/hubspot-theme.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,53 +1,61 @@
-import { Link, Route, Routes } from "react-router-dom";
+import { NavLink, Route, Routes } from "react-router-dom";
 import ContactsList from "./pages/ContactsList";
 import ContactDetail from "./pages/ContactDetail";
 import CompaniesPage from "./pages/CompaniesPage";
 import DashboardPage from "./pages/DashboardPage";
+import type { CSSProperties } from "react";
+
+const navStyle = ({ isActive }: { isActive: boolean }): CSSProperties => ({
+  display: "block",
+  padding: "8px 10px",
+  borderRadius: 8,
+  color: isActive ? "#8a3b20" : "inherit",
+  background: isActive ? "#fff5f2" : "transparent",
+  fontWeight: isActive ? 600 : undefined,
+  textDecoration: "none",
+});
 
 export default function App() {
   return (
-    <div style={{ padding: "24px" }}>
-      <header
+    <div style={{ display: "grid", gridTemplateColumns: "240px 1fr", minHeight: "100%" }}>
+      <aside
         style={{
-          maxWidth: 1120,
-          margin: "0 auto",
-          padding: "12px 0 20px",
+          background: "#fff",
+          borderRight: "1px solid var(--border)",
+          padding: 16,
           display: "flex",
-          alignItems: "baseline",
-          gap: 24,
+          flexDirection: "column",
+          gap: 8,
         }}
       >
-        <h1 style={{ margin: 0 }}>Synergy CRM — LIVE</h1>
-        <p style={{ margin: 0, opacity: 0.7 }}>Vite · React · Router · HubSpot theme</p>
-      </header>
-
-      <nav
-        style={{
-          maxWidth: 1120,
-          margin: "0 auto",
-          display: "flex",
-          gap: 16,
-          paddingBottom: 12,
-        }}
-      >
-        <Link to="/">Contacts</Link>
-        <Link to="/companies">Companies</Link>
-        <Link to="/dashboard">Dashboard</Link>
-        <div style={{ marginLeft: "auto", display: "flex", gap: 16 }}>
-          <a href="#" onClick={(e) => e.preventDefault()}>+ New Contact</a>
-          <a href="#" onClick={(e) => e.preventDefault()}>+ New Company</a>
-        </div>
-      </nav>
-
-      <main style={{ maxWidth: 1120, margin: "0 auto" }}>
-        <Routes>
-          <Route path="/" element={<ContactsList />} />
-          <Route path="/contacts/:id" element={<ContactDetail />} />
-          <Route path="/companies" element={<CompaniesPage />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="*" element={<ContactsList />} />
-        </Routes>
-      </main>
+        <h1 style={{ fontSize: 18, margin: "0 0 12px" }}>Synergy CRM</h1>
+        <NavLink to="/" end style={navStyle}>
+          Contacts
+        </NavLink>
+        <NavLink to="/companies" style={navStyle}>
+          Companies
+        </NavLink>
+        <NavLink to="/dashboard" style={navStyle}>
+          Dashboard
+        </NavLink>
+      </aside>
+      <div style={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <header style={{ padding: "24px 24px 0" }}>
+          <h1 style={{ margin: 0 }}>Synergy CRM — LIVE</h1>
+          <p style={{ margin: 0, opacity: 0.7 }}>
+            Vite · React · Router · HubSpot theme
+          </p>
+        </header>
+        <main style={{ padding: 24, flex: 1 }}>
+          <Routes>
+            <Route path="/" element={<ContactsList />} />
+            <Route path="/contacts/:id" element={<ContactDetail />} />
+            <Route path="/companies" element={<CompaniesPage />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="*" element={<ContactsList />} />
+          </Routes>
+        </main>
+      </div>
     </div>
   );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "/hubspot-theme.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";

--- a/web/src/pages/CompaniesPage.tsx
+++ b/web/src/pages/CompaniesPage.tsx
@@ -2,9 +2,10 @@ export default function CompaniesPage() {
   return (
     <section>
       <div className="panel">
-        <div className="panel__header">
-          <h3 style={{ margin: 0 }}>Companies</h3>
-          <button className="button">Create company</button>
+        <div className="panel-header">
+          <h3 className="title">Companies</h3>
+          <div className="spacer" />
+          <button className="btn btn-primary">Create company</button>
         </div>
         <p style={{ opacity: 0.8 }}>Placeholder view for now.</p>
       </div>

--- a/web/src/pages/ContactDetail.tsx
+++ b/web/src/pages/ContactDetail.tsx
@@ -5,22 +5,42 @@ export default function ContactDetail() {
   return (
     <section>
       <div className="panel">
-        <div className="panel__header" style={{ gap: 12 }}>
-          <Link to="/" className="button button--secondary">Back</Link>
-          <h3 style={{ margin: 0 }}>Contact</h3>
-          <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
-            <button className="button">Save Contact</button>
-          </div>
+        <div className="panel-header">
+          <Link to="/" className="btn">
+            Back
+          </Link>
+          <h3 className="title">Contact</h3>
+          <div className="spacer" />
+          <button className="btn btn-primary">Save Contact</button>
         </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
-          <div><label>Given names</label><input className="input" defaultValue={id} /></div>
-          <div><label>Surname</label><input className="input" /></div>
-          <div><label>Phone</label><input className="input" /></div>
-          <div><label>Email</label><input className="input" /></div>
-          <div><label>Company</label><input className="input" /></div>
-          <div><label>Last seen</label><input className="input" value={new Date().toISOString()} readOnly /></div>
-          <div style={{ gridColumn: "1 / -1" }}>
-            <label>Notes</label><textarea className="textarea" rows={6} />
+        <div className="grid-2">
+          <div className="field">
+            <label className="label">Given names</label>
+            <input className="input" defaultValue={id} />
+          </div>
+          <div className="field">
+            <label className="label">Surname</label>
+            <input className="input" />
+          </div>
+          <div className="field">
+            <label className="label">Phone</label>
+            <input className="input" />
+          </div>
+          <div className="field">
+            <label className="label">Email</label>
+            <input className="input" />
+          </div>
+          <div className="field">
+            <label className="label">Company</label>
+            <input className="input" />
+          </div>
+          <div className="field">
+            <label className="label">Last seen</label>
+            <input className="input" value={new Date().toISOString()} readOnly />
+          </div>
+          <div className="field" style={{ gridColumn: "1 / -1" }}>
+            <label className="label">Notes</label>
+            <textarea className="input" rows={6} />
           </div>
         </div>
       </div>

--- a/web/src/pages/ContactsList.tsx
+++ b/web/src/pages/ContactsList.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
-type Contact = { id: string; name: string; email: string; company?: string };
+interface Contact {
+  id: string;
+  name: string;
+  email: string;
+  company?: string;
+}
 
 const SEED: Contact[] = [
   { id: "bruce", name: "Bruce Wayne", email: "bruce@wayne.com", company: "Wayne Enterprises" },
@@ -22,42 +27,51 @@ export default function ContactsList() {
           const data = await res.json();
           if (!cancelled && Array.isArray(data)) setContacts(data);
         }
-      } catch {}
-      finally { if (!cancelled) setLoading(false); }
+      } catch {
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (
     <section>
       <div className="panel">
-        <div className="panel__header">
-          <h3 style={{ margin: 0 }}>Contacts</h3>
-          <button className="button">Create contact</button>
+        <div className="panel-header">
+          <h3 className="title">Contacts</h3>
+          <div className="spacer" />
+          <button className="btn btn-primary">Create contact</button>
         </div>
-        <div className="table">
-          <div className="table__row table__row--head">
-            <div className="table__cell">Name</div>
-            <div className="table__cell">Company</div>
-            <div className="table__cell">Email</div>
-            <div className="table__cell">Actions</div>
-          </div>
-          {contacts.map((c) => (
-            <div className="table__row" key={c.id}>
-              <div className="table__cell">{c.name}</div>
-              <div className="table__cell">{c.company ?? "-"}</div>
-              <div className="table__cell">{c.email}</div>
-              <div className="table__cell">
-                <Link to={`/contacts/${encodeURIComponent(c.id)}`}>Open</Link>
-              </div>
-            </div>
-          ))}
-          {loading && (
-            <div className="table__row">
-              <div className="table__cell">Loading…</div>
-            </div>
-          )}
-        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Company</th>
+              <th>Email</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {contacts.map((c) => (
+              <tr key={c.id}>
+                <td>{c.name}</td>
+                <td>{c.company ?? "-"}</td>
+                <td>{c.email}</td>
+                <td>
+                  <Link to={`/contacts/${encodeURIComponent(c.id)}`}>Open</Link>
+                </td>
+              </tr>
+            ))}
+            {loading && (
+              <tr>
+                <td colSpan={4}>Loading…</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </section>
   );

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -2,13 +2,28 @@ export default function DashboardPage() {
   return (
     <section>
       <div className="panel">
-        <div className="panel__header">
-          <h3 style={{ margin: 0 }}>Dashboard</h3>
+        <div className="panel-header">
+          <h3 className="title">Dashboard</h3>
         </div>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 16 }}>
-          <div className="card"><strong>Open Cases</strong><div>0</div></div>
-          <div className="card"><strong>Total Contacts</strong><div>2 (seed)</div></div>
-          <div className="card"><strong>Companies</strong><div>2 (seed)</div></div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+            gap: 16,
+          }}
+        >
+          <div className="panel">
+            <strong>Open Cases</strong>
+            <div>0</div>
+          </div>
+          <div className="panel">
+            <strong>Total Contacts</strong>
+            <div>2 (seed)</div>
+          </div>
+          <div className="panel">
+            <strong>Companies</strong>
+            <div>2 (seed)</div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- implement HubSpot-themed layout with sidebar navigation
- adopt theme classes for contact list, detail, companies, and dashboard pages
- load hubspot theme stylesheet in application entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_68b26831c1b48329ae80b826d33831ee