### PR TITLE
Fix build step for Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -20,22 +20,19 @@ jobs:
       - name: Install & build frontend
         working-directory: web
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci --no-audit --no-fund
-          else
-            npm install --no-audit --no-fund
-          fi
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npm run build
       - name: Install & compile API
         working-directory: api
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci --no-audit --no-fund
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+          if [ -f tsconfig.json ]; then
+            npx --yes --package typescript tsc -p .
           else
-            npm install --no-audit --no-fund
+            echo "No tsconfig.json, skipping TypeScript compile"
           fi
-          npx tsc
       - name: Deploy to Azure Static Web Apps
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN != '' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
@@ -44,3 +41,6 @@ jobs:
           app_location: web
           api_location: api
           output_location: dist
+      - name: Skip deployment (missing token)
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN == '' }}
+        run: echo 'AZURE_STATIC_WEB_APPS_API_TOKEN not set; skipping deployment.'

--- a/api/package.json
+++ b/api/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "@azure/functions": "^3.5.0",
     "@azure/cosmos": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18"
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- ensure HubSpot theme stylesheet is referenced once in `index.html`
- install dependencies before building frontend and API; compile API only when `tsconfig.json` exists
- skip Azure Static Web Apps deployment when no API token is provided

## Testing
- `npm install --no-audit --no-fund` (api) *(403 Forbidden for @azure/cosmos)*
- `npm test` (api) *(missing script: "test")*
- `npx --yes --package typescript tsc -p . --noEmit` (api) *(403 Forbidden for typescript)*
- `npm install --no-audit --no-fund` (web) *(403 Forbidden for @types/react)*
- `npm test` (web) *(missing script: "test")*
- `npx --yes --package typescript tsc -p . --noEmit` (web) *(403 Forbidden for typescript)*

------
https://chatgpt.com/codex/tasks/task_b_68b28297939483298e561dc161b85c10