### PR TITLE
Fix build step for Azure Static Web Apps

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -18,11 +18,13 @@ jobs:
         with:
           node-version: 18
       - name: Install & build frontend
+        id: web_build
         working-directory: web
         run: |
           npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npm run build
       - name: Install & compile API
+        id: api_build
         working-directory: api
         run: |
           npm ci --no-audit --no-fund || npm install --no-audit --no-fund
@@ -32,7 +34,7 @@ jobs:
             echo "No tsconfig.json, skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.outcome == 'success' && steps.api_build.outcome == 'success' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -32,7 +32,7 @@ jobs:
             echo "No tsconfig.json, skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN != '' }}
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
@@ -42,5 +42,5 @@ jobs:
           api_location: api
           output_location: dist
       - name: Skip deployment (missing token)
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN == '' }}
+        if: ${{ !secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
         run: echo 'AZURE_STATIC_WEB_APPS_API_TOKEN not set; skipping deployment.'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -21,6 +21,7 @@ jobs:
         id: web_build
         working-directory: web
         run: |
+          # Install dependencies with npm ci, fallback to npm install, then build
           npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npm run build
       - name: Install & compile API

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -34,7 +34,7 @@ jobs:
             echo "No tsconfig.json, skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.outcome == 'success' && steps.api_build.outcome == 'success' }}
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.conclusion == 'success' && steps.api_build.conclusion == 'success' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -20,22 +20,19 @@ jobs:
       - name: Install & build frontend
         working-directory: web
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci --no-audit --no-fund
-          else
-            npm install --no-audit --no-fund
-          fi
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npm run build
       - name: Install & compile API
         working-directory: api
         run: |
-          if [ -f package-lock.json ]; then
-            npm ci --no-audit --no-fund
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+          if [ -f tsconfig.json ]; then
+            npx --yes --package typescript tsc -p .
           else
-            npm install --no-audit --no-fund
+            echo "No tsconfig.json, skipping TypeScript compile"
           fi
-          npx tsc
       - name: Deploy to Azure Static Web Apps
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN != '' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
@@ -44,3 +41,6 @@ jobs:
           app_location: web
           api_location: api
           output_location: dist
+      - name: Skip deployment (missing token)
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN == '' }}
+        run: echo 'AZURE_STATIC_WEB_APPS_API_TOKEN not set; skipping deployment.'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -45,4 +45,4 @@ jobs:
           output_location: dist
       - name: Skip deployment (missing token)
         if: ${{ !secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-        run: echo 'AZURE_STATIC_WEB_APPS_API_TOKEN not set; skipping deployment.'
+        run: echo "AZURE_STATIC_WEB_APPS_API_TOKEN not set; skipping deployment."

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           if [ -f tsconfig.json ]; then
+            # Compile TypeScript sources
             npx --yes --package typescript tsc -p .
           else
             echo "No tsconfig.json; skipping TypeScript compile"

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -31,7 +31,7 @@ jobs:
           if [ -f tsconfig.json ]; then
             npx --yes --package typescript tsc -p .
           else
-            echo "No tsconfig.json, skipping TypeScript compile"
+            echo "No tsconfig.json detected; skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
         if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.conclusion == 'success' && steps.api_build.conclusion == 'success' }}

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -27,12 +27,15 @@ jobs:
         id: api_build
         working-directory: api
         run: |
-          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
-          if [ -f tsconfig.json ]; then
-            # Compile TypeScript sources
-            npx --yes --package typescript tsc -p .
+          if [ -f package.json ]; then
+            npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+            if [ -f tsconfig.json ]; then
+              npx --yes --package typescript tsc -p .
+            else
+              echo "No tsconfig.json; skipping TypeScript compile"
+            fi
           else
-            echo "No tsconfig.json; skipping TypeScript compile"
+            echo "No /api/package.json; skipping API step."
           fi
       - name: Deploy to Azure Static Web Apps
         if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.conclusion == 'success' && steps.api_build.conclusion == 'success' }}

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -27,15 +27,11 @@ jobs:
         id: api_build
         working-directory: api
         run: |
-          if [ -f package.json ]; then
-            npm ci --no-audit --no-fund || npm install --no-audit --no-fund
-            if [ -f tsconfig.json ]; then
-              npx --yes --package typescript tsc -p .
-            else
-              echo "No tsconfig.json; skipping TypeScript compile"
-            fi
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
+          if [ -f tsconfig.json ]; then
+            npx --yes --package typescript tsc -p .
           else
-            echo "No /api/package.json; skipping API step."
+            echo "No tsconfig.json; skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
         if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.conclusion == 'success' && steps.api_build.conclusion == 'success' }}

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -31,7 +31,7 @@ jobs:
           if [ -f tsconfig.json ]; then
             npx --yes --package typescript tsc -p .
           else
-            echo "No tsconfig.json detected; skipping TypeScript compile"
+            echo "No tsconfig.json; skipping TypeScript compile"
           fi
       - name: Deploy to Azure Static Web Apps
         if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN && steps.web_build.conclusion == 'success' && steps.api_build.conclusion == 'success' }}

--- a/api/package.json
+++ b/api/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "@azure/functions": "^3.5.0",
     "@azure/cosmos": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^18"
   }
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Synergy CRM</title>
-    <link rel="stylesheet" href="/hubspot-theme.css?v7" />
+    <link rel="stylesheet" href="/hubspot-theme.css?v7">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- ensure HubSpot theme stylesheet is referenced once in `index.html`
- install dependencies before building frontend and API; compile API only when `tsconfig.json` exists
- skip Azure Static Web Apps deployment when no API token is provided

## Testing
- `npm install --no-audit --no-fund` (api) *(403 Forbidden for @azure/cosmos)*
- `npm test` (api) *(missing script: "test")*
- `npx --yes --package typescript tsc -p . --noEmit` (api) *(403 Forbidden for typescript)*
- `npm install --no-audit --no-fund` (web) *(403 Forbidden for @types/react)*
- `npm test` (web) *(missing script: "test")*
- `npx --yes --package typescript tsc -p . --noEmit` (web) *(403 Forbidden for typescript)*

------
https://chatgpt.com/codex/tasks/task_b_68b28297939483298e561dc161b85c10